### PR TITLE
Capstone works under 5.014 as well.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use 5.022000;
+use 5.014000;
 use ExtUtils::MakeMaker;
 
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence

--- a/lib/Capstone.pm
+++ b/lib/Capstone.pm
@@ -1,6 +1,6 @@
 package Capstone;
 
-use 5.022000;
+use 5.014000;
 use strict;
 use warnings;
 require Exporter;


### PR DESCRIPTION
Hi Tosh,
Your Capstone module works under Perl 5.14 and also under 5.20 as I have tested. Please do not forcibly restrict it to just 5.22.

Also your Makefile.PL does not check if Capstone is installed before trying to compile. I will send another pull request fixing that soon.

Thanks
Vikas.
