### PR TITLE
Using pkg-config to detect if Capstone is already installed and using…

### DIFF
--- a/Capstone.xs
+++ b/Capstone.xs
@@ -29,7 +29,11 @@
 
 #include "ppport.h"
 
+#ifdef CAPSTONE_FROM_PKGCONFIG
+#include <capstone.h>
+#else
 #include <capstone/capstone.h>
+#endif
 
 
 MODULE = Capstone   PACKAGE = cshPtr  PREFIX = csh_

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,6 +3,11 @@ use ExtUtils::MakeMaker;
 
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
+my $cflags = `pkg-config --cflags capstone`;
+chomp $cflags if $cflags;
+my $define = '-DCAPSTONE_FROM_PKGCONFIG' if $cflags;
+my $ldflags = `pkg-config --libs capstone` || '-lcapstone';
+chomp $ldflags if $ldflags;
 
 WriteMakefile(
     NAME              => 'Capstone',
@@ -11,7 +16,7 @@ WriteMakefile(
     ABSTRACT_FROM     => 'lib/Capstone.pm',
     AUTHOR            => 'Tosh <tosh@t0x0sh.org>',
     LICENSE           => 'GPL_3',
-    LIBS              => ['-lcapstone'],
-    DEFINE            => '',
-    INC               => '-I.',
+    LIBS              => [$ldflags],
+    DEFINE            => $define || '',
+    INC               => ($cflags || '') . ' -I.',
 );


### PR DESCRIPTION
Hello @t00sh 

This modification allows the Makefile to pick the already installed Capstone in any arbitrary location (not necessarily `/usr/lib` or `/usr/local/lib`) as per the `pkg-config` file. So if you have installed a custom version of Capstone in your home directory, this module can pick that up if you prefer. 

If that is not available, then goes back to your old method.

Thanks.
